### PR TITLE
fix: support all accumulators in enum forward deserialization

### DIFF
--- a/instant-xml-macros/src/de.rs
+++ b/instant-xml-macros/src/de.rs
@@ -170,9 +170,9 @@ fn deserialize_forward_enum(
         let v_ident = &variant.ident;
         variants.extend(
             quote!(if <#no_lifetime_type as FromXml>::matches(id, None) {
-                let mut value = None;
+                let mut value = <#no_lifetime_type as FromXml>::Accumulator::default();
                 <#no_lifetime_type as FromXml>::deserialize(&mut value, #field_str, deserializer)?;
-                *into = value.map(#ident::#v_ident);
+                *into = ::instant_xml::Accumulate::try_done(value, #field_str).map(#ident::#v_ident).ok();
             }),
         );
     }

--- a/instant-xml/tests/forward-enum.rs
+++ b/instant-xml/tests/forward-enum.rs
@@ -4,19 +4,19 @@ use similar_asserts::assert_eq;
 
 use instant_xml::{from_str, to_string, FromXml, ToXml};
 
-#[derive(Debug, Eq, FromXml, PartialEq, ToXml)]
+#[derive(Debug, FromXml, PartialEq, ToXml)]
 #[xml(forward)]
 enum Foo {
     Bar(Bar),
     Baz(Baz),
 }
 
-#[derive(Debug, Eq, FromXml, PartialEq, ToXml)]
+#[derive(Debug, FromXml, PartialEq, ToXml)]
 struct Bar {
     bar: u8,
 }
 
-#[derive(Debug, Eq, FromXml, PartialEq, ToXml)]
+#[derive(Debug, FromXml, PartialEq, ToXml)]
 struct Baz {
     baz: String,
 }


### PR DESCRIPTION
Previously limited to Option<T> only.

The following does not compile in main:

```rust
#[derive(Debug, PartialEq, ToXml, FromXml)]
#[xml(forward)]
enum FooCow<'a> {
    Bar(Cow<'a, [BarBorrowed<'a>]>),
    Baz(Cow<'a, [BazBorrowed<'a>]>),
}
```