### PR TITLE
Impl (de)serialization for chrono::NaiveDateTime

### DIFF
--- a/instant-xml/tests/chrono.rs
+++ b/instant-xml/tests/chrono.rs
@@ -1,14 +1,16 @@
 #![cfg(feature = "chrono")]
 
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
 use similar_asserts::assert_eq;
 
 use instant_xml::{from_str, to_string, FromXml, ToXml};
 
 #[derive(Debug, Eq, PartialEq, FromXml, ToXml)]
-struct Test {
-    dt: DateTime<Utc>,
+struct Test<T> {
+    dt: T,
 }
+
+type TestUtcDateTime = Test<DateTime<Utc>>;
 
 #[test]
 fn datetime() {
@@ -16,8 +18,19 @@ fn datetime() {
     let test = Test { dt };
     let xml = "<Test><dt>2022-11-21T21:17:23+00:00</dt></Test>";
     assert_eq!(to_string(&test).unwrap(), xml);
-    assert_eq!(from_str::<Test>(xml).unwrap(), test);
+    assert_eq!(from_str::<TestUtcDateTime>(xml).unwrap(), test);
 
     let zulu = xml.replace("+00:00", "Z");
-    assert_eq!(from_str::<Test>(&zulu).unwrap(), test);
+    assert_eq!(from_str::<TestUtcDateTime>(&zulu).unwrap(), test);
+}
+
+type TestNaiveDateTime = Test<NaiveDateTime>;
+
+#[test]
+fn naive_datetime() {
+    let dt = NaiveDateTime::parse_from_str("2022-11-21T21:17:23", "%Y-%m-%dT%H:%M:%S").unwrap();
+    let test = Test { dt };
+    let xml = "<Test><dt>2022-11-21T21:17:23</dt></Test>";
+    assert_eq!(to_string(&test).unwrap(), xml);
+    assert_eq!(from_str::<TestNaiveDateTime>(xml).unwrap(), test);
 }


### PR DESCRIPTION
Adds implementations of `ToXml` and `FromXml` for `chrono::NaiveDateTime`.