### PR TITLE
Added unit test of direct element with no value

### DIFF
--- a/instant-xml/tests/direct-no-value.rs
+++ b/instant-xml/tests/direct-no-value.rs
@@ -1,0 +1,22 @@
+use instant_xml::{from_str, to_string, FromXml, ToXml};
+
+#[derive(ToXml, FromXml, Debug, PartialEq, Eq)]
+struct Foo {
+    #[xml(attribute)]
+    attribute: Option<String>,
+    #[xml(direct)]
+    direct: Option<String>,
+}
+
+
+#[test]
+fn serde_direct_no_value_test() {
+    let v = Foo {
+        attribute: Some("Attribute text".to_string()),
+        direct: None,
+    };
+    let xml = r#"<Foo attribute="Attribute text"/>"#;
+
+    assert_eq!(xml, to_string(&v).unwrap()); //this fails because the serializer still writes "<Foo attribute=\"Attribute text\"></Foo>"
+    assert_eq!(from_str::<Foo>(&xml).unwrap(), v); //this fails because the serializer still writes Some("") to direct
+}


### PR DESCRIPTION
Currently when the #[xml(direct)] field does not have a value it provide undesirable behaviors both on serialization and deserialization. 

**Serialization** 
In the case of serialization, it still `serializer.write_close` always even if there are No element or custom namespace to deal with. Ideally in this case it will just `serializer.end_empty` instead. 

This is just to deal with less characters in the output xml string. Note: Deserialization of xml with empty ending works just fine overall as far as my current testing goes. 

**Deserialization** 
In the case of deserialization, it always reads the element value as Some("") even when the value does not exist in the XML. This is just wrong behavior overall I think. 

Note: This is just the test case to show the failures, I have not attempted to fix it yet. I am also okay if both the issue should be dealt with as 2 separate behaviors. 