### PR TITLE
Make namespace paths consistently refer to full namespace

### DIFF
--- a/instant-xml-macros/Cargo.toml
+++ b/instant-xml-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instant-xml-macros"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.61"
 workspace = ".."

--- a/instant-xml-macros/src/ser.rs
+++ b/instant-xml-macros/src/ser.rs
@@ -397,17 +397,7 @@ impl StructOutput {
 
             let (ns, error) = match &field_meta.ns.uri {
                 Some(Namespace::Path(path)) => match path.get_ident() {
-                    Some(prefix) => match &meta.ns.prefixes.get(&prefix.to_string()) {
-                        Some(ns) => (quote!(#ns), quote!()),
-                        None => (
-                            quote!(""),
-                            syn::Error::new(
-                                field_meta.ns.uri.span(),
-                                format!("unknown prefix `{prefix}` (prefix must be defined on the field's type)"),
-                            )
-                            .into_compile_error(),
-                        ),
-                    },
+                    Some(path) => (quote!(#path), quote!()),
                     None => (
                         quote!(""),
                         syn::Error::new(

--- a/instant-xml/Cargo.toml
+++ b/instant-xml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instant-xml"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.61"
 workspace = ".."
@@ -12,7 +12,7 @@ readme = "../README.md"
 
 [dependencies]
 chrono = { version = "0.4.23", optional = true }
-macros = { package = "instant-xml-macros", version = "0.5.0", path = "../instant-xml-macros" }
+macros = { package = "instant-xml-macros", version = "0.6", path = "../instant-xml-macros" }
 thiserror = "2.0.3"
 xmlparser = "0.13.3"
 

--- a/instant-xml/tests/attributes.rs
+++ b/instant-xml/tests/attributes.rs
@@ -32,7 +32,7 @@ fn empty() {
     );
 }
 
-#[derive(ToXml)]
+#[derive(FromXml, ToXml, PartialEq)]
 #[xml(ns(bar = BAR))]
 struct NoPrefixAttrNs {
     #[xml(attribute, ns(BAR))]
@@ -43,8 +43,8 @@ const BAR: &str = "BAR";
 
 #[test]
 fn no_prefix_attr_ns() {
-    assert_eq!(
-        to_string(&NoPrefixAttrNs { flag: true }).unwrap(),
-        "<NoPrefixAttrNs xmlns:bar=\"BAR\" bar:flag=\"true\" />"
-    );
+    let v = NoPrefixAttrNs { flag: true };
+    let xml = "<NoPrefixAttrNs xmlns:bar=\"BAR\" bar:flag=\"true\" />";
+    assert_eq!(to_string(&v).unwrap(), xml);
+    assert_eq!(from_str::<NoPrefixAttrNs>(xml).unwrap(), v);
 }

--- a/instant-xml/tests/attributes.rs
+++ b/instant-xml/tests/attributes.rs
@@ -33,11 +33,13 @@ fn empty() {
 }
 
 #[derive(ToXml)]
-#[xml(ns(bar = "BAR"))]
+#[xml(ns(bar = BAR))]
 struct NoPrefixAttrNs {
-    #[xml(attribute, ns(bar))]
+    #[xml(attribute, ns(BAR))]
     flag: bool,
 }
+
+const BAR: &str = "BAR";
 
 #[test]
 fn no_prefix_attr_ns() {


### PR DESCRIPTION
`FromXml` and `ToXml` treated `ns(foo)` on fields inconsistently:

- `FromXml` treated `foo` as a path to a constant containing the full namespace string
- `ToXml` treated `foo` as a namespace prefix defined on the container type

Change the `ToXml` treatment to match the `FromXml` treatment, favoring less indirection.

Use a semver-incompatible version bump to signal the potential incompatibility.

cc @vshashi01