### PR TITLE
Remove scheduled CI workflows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: ['main']
   pull_request:
-  schedule:
-    - cron: "34 6 * * 5"
 
 jobs:
   test:


### PR DESCRIPTION
This avoids GitHub disabling the workflow after a while.