### PR TITLE
fixed number parsing when &str contains whitespace

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.62.0
+          toolchain: 1.65.0
       - run: cargo check --all-features --lib
 
   lint:

--- a/instant-xml-macros/Cargo.toml
+++ b/instant-xml-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "instant-xml-macros"
 version = "0.6.0"
 edition = "2021"
-rust-version = "1.62"
+rust-version = "1.65"
 workspace = ".."
 license = "Apache-2.0 OR MIT"
 description = "Procedural macros for instant-xml"

--- a/instant-xml/Cargo.toml
+++ b/instant-xml/Cargo.toml
@@ -2,7 +2,7 @@
 name = "instant-xml"
 version = "0.6.0"
 edition = "2021"
-rust-version = "1.62"
+rust-version = "1.65"
 workspace = ".."
 license = "Apache-2.0 OR MIT"
 description = "A more rigorous way to map XML to Rust types"

--- a/instant-xml/src/impls.rs
+++ b/instant-xml/src/impls.rs
@@ -193,10 +193,18 @@ macro_rules! from_xml_for_number {
                     return Err(Error::DuplicateValue(field));
                 }
 
-                let mut value = None;
-                FromXmlStr::<Self>::deserialize(&mut value, field, deserializer)?;
-                if let Some(value) = value {
-                    *into = Some(value.0);
+                let Some(value) = deserializer.take_str()? else {
+                    return Ok(());
+                };
+
+                match <$typ>::from_str(value.as_ref().trim()) {
+                    Ok(value) => *into = Some(value),
+                    Err(_) => {
+                        return Err(Error::UnexpectedValue(format!(
+                            "unable to parse number {} from `{value}` for {field}",
+                            type_name::<$typ>()
+                        )))
+                    }
                 }
 
                 Ok(())

--- a/instant-xml/tests/number.rs
+++ b/instant-xml/tests/number.rs
@@ -1,0 +1,38 @@
+use instant_xml::{from_str, FromXml};
+use similar_asserts::assert_eq;
+
+#[derive(FromXml, PartialEq, Debug)]
+struct Number {
+    pub i_8: i8,
+    pub i_16: i16,
+    pub i_32: i32,
+    pub i_64: i64,
+    pub i_size: isize,
+    pub u_8: u8,
+    pub u_16: u16,
+    pub u_32: u32,
+    pub u_64: u64,
+    pub u_size: usize,
+    pub f_32: f32,
+    pub f_64: f64,
+}
+
+#[test]
+fn deserialize_spaced_numbers_fields() {
+    let v = Number {
+        i_8: -1,
+        i_16: -32456,
+        i_32: -6034568,
+        i_64: -1245789630056,
+        i_size: -125698389,
+        u_8: 9,
+        u_16: 64469,
+        u_32: 6034568,
+        u_64: 99245789630056,
+        u_size: 125698389,
+        f_32: -12.5683,
+        f_64: 104568.568932,
+    };
+    let xml = r#"<Number><i_8>  -1 </i_8><i_16>-32456 </i_16><i_32>-6034568 </i_32><i_64>-1245789630056 </i_64><i_size>-125698389 </i_size><u_8>9 </u_8><u_16>64469   </u_16><u_32>6034568 </u_32><u_64> 99245789630056 </u_64><u_size>125698389 </u_size><f_32>    -12.5683   </f_32><f_64>  104568.568932 </f_64></Number>"#;
+    assert_eq!(v, from_str(xml).unwrap());
+}


### PR DESCRIPTION
Currently, when the field contains whitespace the deserialization immediately fails for numbers.

```
use instant_xml::{from_str, FromXml};
use similar_asserts::assert_eq;

#[derive(FromXml, PartialEq, Debug)]
struct Number {
    pub i_8: i8,
    pub i_16: i16,
    pub i_32: i32,
}

#[test]
fn deserialize_spaced_numbers_fields() {
    let v = Number {
        i_8: -1,
        i_16: -32456_i16,
        i_32: -6034568_i32,
    };
    let xml = r#"<Number><i_8>  -1 </i_8><i_16>-32456 </i_16><i_32>-6034568 </i_32></Number>"#;
    assert_eq!(v, from_str(xml).unwrap());
}
```

Proposed a solution to trim the whitespaces for the from_xml_for_number macro.