### PR TITLE
Add the ability to get all the namespaces found in the de-serialized XML document

### DIFF
--- a/instant-xml/tests/de-ns.rs
+++ b/instant-xml/tests/de-ns.rs
@@ -1,6 +1,8 @@
 use similar_asserts::assert_eq;
 
-use instant_xml::{from_str, Error, FromXml};
+use instant_xml::{from_str, from_str_with_namespaces, Error, FromXml};
+
+use std::collections::BTreeMap;
 
 #[derive(Debug, Eq, PartialEq, FromXml)]
 struct NestedWrongNamespace {
@@ -178,4 +180,327 @@ fn dashed_ns() {
         from_str("<DashedNs xmlns=\"URI\" xmlns:da_sh.ed-ns=\"dashed\"><da_sh.ed-ns:element>hello</da_sh.ed-ns:element></DashedNs>"),
         Ok(DashedNs { element: "hello".to_owned() })
     );
+}
+
+#[test]
+fn namespace_extraction_basic() {
+    let xml = r#"<NestedDe xmlns="URI" xmlns:bar="BAZ"><bar:flag>true</bar:flag></NestedDe>"#;
+
+    let (result, namespaces) = from_str_with_namespaces::<NestedDe>(xml).unwrap();
+
+    assert_eq!(result, NestedDe { flag: true });
+
+    let mut expected = BTreeMap::new();
+    expected.insert("".to_string(), "URI".to_string()); // default namespace
+    expected.insert("bar".to_string(), "BAZ".to_string());
+    expected.insert(
+        "xml".to_string(),
+        "http://www.w3.org/XML/1998/namespace".to_string(),
+    );
+
+    assert_eq!(namespaces, expected);
+}
+
+#[test]
+fn namespace_extraction_with_xml_lang() {
+    let xml = r#"<NestedDe xml:lang="en" xmlns="URI" xmlns:bar="BAZ"><bar:flag>true</bar:flag></NestedDe>"#;
+
+    let (result, namespaces) = from_str_with_namespaces::<NestedDe>(xml).unwrap();
+
+    assert_eq!(result, NestedDe { flag: true });
+
+    let mut expected = BTreeMap::new();
+    expected.insert("".to_string(), "URI".to_string());
+    expected.insert("bar".to_string(), "BAZ".to_string());
+    expected.insert(
+        "xml".to_string(),
+        "http://www.w3.org/XML/1998/namespace".to_string(),
+    );
+
+    assert_eq!(namespaces, expected);
+}
+
+#[test]
+fn namespace_extraction_nested_declarations() {
+    let xml = r#"<StructWithCorrectNestedNamespace xmlns="URI" xmlns:bar="BAZ">
+        <NestedDe xmlns="URI" xmlns:bar="BAZ">
+            <bar:flag>true</bar:flag>
+        </NestedDe>
+    </StructWithCorrectNestedNamespace>"#;
+
+    let (result, namespaces) =
+        from_str_with_namespaces::<StructWithCorrectNestedNamespace>(xml).unwrap();
+
+    assert_eq!(
+        result,
+        StructWithCorrectNestedNamespace {
+            test: NestedDe { flag: true }
+        }
+    );
+
+    let mut expected = BTreeMap::new();
+    expected.insert("".to_string(), "URI".to_string());
+    expected.insert("bar".to_string(), "BAZ".to_string());
+    expected.insert(
+        "xml".to_string(),
+        "http://www.w3.org/XML/1998/namespace".to_string(),
+    );
+
+    assert_eq!(namespaces, expected);
+}
+
+#[test]
+fn namespace_extraction_multiple_prefixes() {
+    let xml = r#"<Root xmlns="DEFAULT" xmlns:foo="ROOT_PREFIXED_1" xmlns:bar="ROOT_PREFIXED_2">
+        <child xmlns:baz="CHILD_PREFIXED_1">content</child>
+    </Root>"#;
+
+    #[derive(Debug, Eq, PartialEq, FromXml)]
+    #[xml(ns("DEFAULT"))]
+    struct Root {
+        child: String,
+    }
+
+    let (result, namespaces) = from_str_with_namespaces::<Root>(xml).unwrap();
+
+    assert_eq!(
+        result,
+        Root {
+            child: "content".to_string()
+        }
+    );
+
+    let mut expected = BTreeMap::new();
+    expected.insert("".to_string(), "DEFAULT".to_string());
+    expected.insert("foo".to_string(), "ROOT_PREFIXED_1".to_string());
+    expected.insert("bar".to_string(), "ROOT_PREFIXED_2".to_string());
+    expected.insert("baz".to_string(), "CHILD_PREFIXED_1".to_string());
+    expected.insert(
+        "xml".to_string(),
+        "http://www.w3.org/XML/1998/namespace".to_string(),
+    );
+
+    assert_eq!(namespaces, expected);
+}
+
+#[test]
+fn namespace_extraction_dashed_prefixes() {
+    let xml = r#"<DashedNs xmlns="URI" xmlns:da_sh.ed-ns="dashed"><da_sh.ed-ns:element>hello</da_sh.ed-ns:element></DashedNs>"#;
+
+    let (result, namespaces) = from_str_with_namespaces::<DashedNs>(xml).unwrap();
+
+    assert_eq!(
+        result,
+        DashedNs {
+            element: "hello".to_owned()
+        }
+    );
+
+    let mut expected = BTreeMap::new();
+    expected.insert("".to_string(), "URI".to_string());
+    expected.insert("da_sh.ed-ns".to_string(), "dashed".to_string());
+    expected.insert(
+        "xml".to_string(),
+        "http://www.w3.org/XML/1998/namespace".to_string(),
+    );
+
+    assert_eq!(namespaces, expected);
+}
+
+#[test]
+fn namespace_extraction_no_namespaces() {
+    let xml = r#"<Root><child>content</child></Root>"#;
+
+    #[derive(Debug, Eq, PartialEq, FromXml)]
+    struct Root {
+        child: String,
+    }
+
+    let (result, namespaces) = from_str_with_namespaces::<Root>(xml).unwrap();
+
+    assert_eq!(
+        result,
+        Root {
+            child: "content".to_string()
+        }
+    );
+
+    let mut expected = BTreeMap::new();
+    expected.insert(
+        "xml".to_string(),
+        "http://www.w3.org/XML/1998/namespace".to_string(),
+    );
+
+    assert_eq!(namespaces, expected);
+}
+
+#[test]
+fn namespace_extraction_only_default_namespace() {
+    let xml = r#"<Root xmlns="DEFAULT"><child>content</child></Root>"#;
+
+    #[derive(Debug, Eq, PartialEq, FromXml)]
+    #[xml(ns("DEFAULT"))]
+    struct Root {
+        child: String,
+    }
+
+    let (result, namespaces) = from_str_with_namespaces::<Root>(xml).unwrap();
+
+    assert_eq!(
+        result,
+        Root {
+            child: "content".to_string()
+        }
+    );
+
+    let mut expected = BTreeMap::new();
+    expected.insert("".to_string(), "DEFAULT".to_string());
+    expected.insert(
+        "xml".to_string(),
+        "http://www.w3.org/XML/1998/namespace".to_string(),
+    );
+
+    assert_eq!(namespaces, expected);
+}
+
+//still need to figure out why this is not working
+// on first look: It seems like the deserializer cannot deal with the case where the child element is a namespaced element?
+#[test]
+fn namespace_extraction_only_prefixed_namespaces() {
+    let xml = r#"<Root xmlns:foo="ROOT_PREFIXED_1" xmlns:bar="ROOT_PREFIXED_2"><foo:child>content</foo:child></Root>"#;
+
+    #[derive(Debug, Eq, PartialEq, FromXml)]
+    struct Root {
+        child: String,
+    }
+
+    let (result, namespaces) = from_str_with_namespaces::<Root>(xml).unwrap();
+
+    assert_eq!(
+        result,
+        Root {
+            child: "content".to_string()
+        }
+    );
+
+    let mut expected = BTreeMap::new();
+    expected.insert("foo".to_string(), "ROOT_PREFIXED_1".to_string());
+    expected.insert("bar".to_string(), "ROOT_PREFIXED_2".to_string());
+    expected.insert(
+        "xml".to_string(),
+        "http://www.w3.org/XML/1998/namespace".to_string(),
+    );
+
+    assert_eq!(namespaces, expected);
+}
+
+#[test]
+fn namespace_extraction_empty_default_namespace() {
+    let xml = r#"<Root xmlns="" xmlns:foo="ROOT_PREFIXED_1"><child>content</child></Root>"#;
+
+    #[derive(Debug, Eq, PartialEq, FromXml)]
+    struct Root {
+        child: String,
+    }
+
+    let (result, namespaces) = from_str_with_namespaces::<Root>(xml).unwrap();
+
+    assert_eq!(
+        result,
+        Root {
+            child: "content".to_string()
+        }
+    );
+
+    let mut expected = BTreeMap::new();
+    expected.insert("".to_string(), "".to_string()); // empty default namespace
+    expected.insert("foo".to_string(), "ROOT_PREFIXED_1".to_string());
+    expected.insert(
+        "xml".to_string(),
+        "http://www.w3.org/XML/1998/namespace".to_string(),
+    );
+
+    assert_eq!(namespaces, expected);
+}
+
+#[test]
+fn namespace_extraction_error_cases() {
+    let xml =
+        r#"<WrongElement xmlns="URI" xmlns:bar="BAZ"><bar:flag>true</bar:flag></WrongElement>"#;
+
+    let result = from_str_with_namespaces::<NestedDe>(xml);
+
+    assert!(result.is_err());
+
+    let xml_correct =
+        r#"<NestedDe xmlns="URI" xmlns:bar="BAZ"><bar:flag>true</bar:flag></NestedDe>"#;
+    let (result, namespaces) = from_str_with_namespaces::<NestedDe>(xml_correct).unwrap();
+
+    assert_eq!(result, NestedDe { flag: true });
+
+    let mut expected = BTreeMap::new();
+    expected.insert("".to_string(), "URI".to_string());
+    expected.insert("bar".to_string(), "BAZ".to_string());
+    expected.insert(
+        "xml".to_string(),
+        "http://www.w3.org/XML/1998/namespace".to_string(),
+    );
+
+    assert_eq!(namespaces, expected);
+}
+
+//still need to figure out why this is not working yet.
+//is this the same issue as above?
+#[test]
+fn namespace_extraction_complex_nested() {
+    let xml = r#"<Root xmlns="http://root.com" xmlns:level1="http://level1.com">
+        <level1:Child xmlns:level2="http://level2.com">
+            <level2:Grandchild xmlns:level3="http://level3.com">
+                <level3:content>text</level3:content>
+            </level2:Grandchild>
+        </level1:Child>
+    </Root>"#;
+
+    #[derive(Debug, Eq, PartialEq, FromXml)]
+    #[xml(ns("http://root.com", level1 = "http://level1.com"))]
+    struct Root {
+        child: Child,
+    }
+
+    #[derive(Debug, Eq, PartialEq, FromXml)]
+    #[xml(ns("http://level1.com", level2 = "http://level2.com"))]
+    struct Child {
+        grandchild: Grandchild,
+    }
+
+    #[derive(Debug, Eq, PartialEq, FromXml)]
+    #[xml(ns("http://level2.com", level3 = "http://level3.com"))]
+    struct Grandchild {
+        content: String,
+    }
+
+    let (result, namespaces) = from_str_with_namespaces::<Root>(xml).unwrap();
+
+    assert_eq!(
+        result,
+        Root {
+            child: Child {
+                grandchild: Grandchild {
+                    content: "text".to_string()
+                }
+            }
+        }
+    );
+
+    let mut expected = BTreeMap::new();
+    expected.insert("".to_string(), "http://root.com".to_string());
+    expected.insert("level1".to_string(), "http://level1.com".to_string());
+    expected.insert("level2".to_string(), "http://level2.com".to_string());
+    expected.insert("level3".to_string(), "http://level3.com".to_string());
+    expected.insert(
+        "xml".to_string(),
+        "http://www.w3.org/XML/1998/namespace".to_string(),
+    );
+
+    assert_eq!(namespaces, expected);
 }


### PR DESCRIPTION
When looking at the proposed solution for issue #95, I realized it does not work for me because what I want to achieve is to get a full list of namespaces and the corresponding prefixes defined for the de-serialized XML doc. 

Based on that, the most obvious solution is to be able to track and return the namespaces encountered by de-serializer's Context object as it de-serializing the document.  

### Proposed Changes 

## Public API 
- Added a new de-serializer function; from_str_with_namespace() that returns the de-serialized object and a map of all the namespaces (BTreeMap<String, String>) found when de-serializing the XML document. 

## Internals
- Added a new field to the de-serializer Context to track all the namespaces
- When the namespaces are encountered during parsing of attribute Tokens, the namespace and its prefix is appended to the map. 
- Note: currently the implementation is basic only such that the last encountered prefix for the same namespace is the tracked prefix. It does not keep track of multiple prefixes that point to the same namespace URI.  
- Added a crate level pub function for de-serializer Context, to get a owned map of all of the namespaces from lib.rs

## Test
- Added tests to test that the new function returns the correct namespaces
- There are still couple of tests failing that I would need to investigate further and probably push some fixes.

## Potential improvements to the current approach 
- Unify the from_str and from_str_with_namespaces function to use the same underlying function so that the de-serializing correctness does not need to be retested per function (Note: Currently the added tests do not test for the correctness of de-serialization itself, only the namespaces, ideally if we keep two unique implementation for deserializing we should extend the tests to both.)
- If the new API adds unnecessary noise to default public API, it should also be possible to isolate the function and all the associated codes to a separate cargo feature such as "namespaces-tracking"

I am also open to an alternative suggestion on how we can achieve similar behavior with a different approach. 