### PR TITLE
Alternative force prefix

### DIFF
--- a/instant-xml-macros/src/lib.rs
+++ b/instant-xml-macros/src/lib.rs
@@ -46,6 +46,7 @@ struct ContainerMeta<'input> {
     rename: Option<Literal>,
     rename_all: RenameRule,
     mode: Option<Mode>,
+    force_prefix: bool,
 }
 
 impl<'input> ContainerMeta<'input> {
@@ -54,6 +55,7 @@ impl<'input> ContainerMeta<'input> {
         let mut rename = Default::default();
         let mut rename_all = Default::default();
         let mut mode = None;
+        let mut force_prefix = false;
 
         for (item, span) in meta_items(&input.attrs) {
             match item {
@@ -69,6 +71,16 @@ impl<'input> ContainerMeta<'input> {
                     None => mode = Some(new),
                     Some(_) => return Err(syn::Error::new(span, "cannot have two modes")),
                 },
+                MetaItem::ForcePrefix => {
+                    if matches!(input.data, syn::Data::Enum(_)) {
+                        return Err(syn::Error::new(
+                            input.span(),
+                            "force_prefix is not allowed on enums",
+                        ));
+                    } else {
+                        force_prefix = true;
+                    }
+                }
                 _ => {
                     return Err(syn::Error::new(
                         span,
@@ -84,6 +96,7 @@ impl<'input> ContainerMeta<'input> {
             rename,
             rename_all,
             mode,
+            force_prefix,
         })
     }
 
@@ -156,6 +169,12 @@ impl FieldMeta {
                 }
                 MetaItem::Mode(_) => {
                     return Err(syn::Error::new(span, "invalid attribute for struct field"));
+                }
+                MetaItem::ForcePrefix => {
+                    return Err(syn::Error::new(
+                        span,
+                        "attribute 'force_prefix' invalid in field xml attribute",
+                    ))
                 }
             }
         }

--- a/instant-xml-macros/src/meta.rs
+++ b/instant-xml-macros/src/meta.rs
@@ -321,6 +321,9 @@ pub(crate) fn meta_items(attrs: &[syn::Attribute]) -> Vec<(MetaItem, Span)> {
                     MetaState::SerializeWith
                 } else if id == "deserialize_with" {
                     MetaState::DeserializeWith
+                } else if id == "force_prefix" {
+                    items.push((MetaItem::ForcePrefix, span));
+                    MetaState::Comma
                 } else {
                     panic!("unexpected key in xml attribute");
                 }
@@ -494,4 +497,5 @@ pub(crate) enum MetaItem {
     RenameAll(Literal),
     SerializeWith(Literal),
     DeserializeWith(Literal),
+    ForcePrefix,
 }

--- a/instant-xml-macros/src/ser.rs
+++ b/instant-xml-macros/src/ser.rs
@@ -184,10 +184,12 @@ fn serialize_struct(
     }
 
     let default_namespace = meta.default_namespace();
+    let force_prefix = meta.force_prefix;
     let cx_len = meta.ns.prefixes.len();
     let mut context = quote!(
         let mut new = ::instant_xml::ser::Context::<#cx_len>::default();
         new.default_ns = #default_namespace;
+        new.force_prefix = #force_prefix;
     );
 
     for (i, (prefix, ns)) in meta.ns.prefixes.iter().enumerate() {
@@ -206,6 +208,7 @@ fn serialize_struct(
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let tag = meta.tag();
     let ident = &input.ident;
+
     quote!(
         impl #impl_generics ToXml for #ident #ty_generics #where_clause {
             fn serialize<W: ::core::fmt::Write + ?::core::marker::Sized>(
@@ -245,6 +248,12 @@ fn serialize_inline_struct(
     } else if let Some(rename) = meta.rename {
         return syn::Error::new(rename.span(), "inline structs cannot be renamed")
             .to_compile_error();
+    } else if meta.force_prefix {
+        return syn::Error::new(
+            input.span(),
+            "inline structs cannot have force_prefix declaration",
+        )
+        .to_compile_error();
     }
 
     let mut out = StructOutput::default();

--- a/instant-xml/src/lib.rs
+++ b/instant-xml/src/lib.rs
@@ -157,6 +157,9 @@
 //!   let msg = Message::Request(Request {});
 //!   assert_eq!(to_string(&msg).unwrap(), "<Request />");
 //!   ```
+//!   
+//! -**`force_prefix`** *(structs only)* - Always serialize a namespace prefix if one is set for this element's namespace.
+//! Does not affect deserialization.
 //!
 //! ## Field attributes
 //!

--- a/instant-xml/src/ser.rs
+++ b/instant-xml/src/ser.rs
@@ -46,17 +46,39 @@ impl<'xml, W: fmt::Write + ?Sized> Serializer<'xml, W> {
             return Err(Error::UnexpectedState("invalid state for element start"));
         }
 
-        let prefix = match (ns == self.default_ns, self.prefixes.get(ns)) {
-            (true, _) => {
+        let force_prefix = cx.as_ref().is_some_and(|cx| cx.force_prefix);
+
+        let prefix = match (ns == self.default_ns, self.prefixes.get(ns), force_prefix) {
+            // Ns != default ns
+            (false, Some(prefix), force_prefix) => {
+                self.output.write_fmt(format_args!("<{prefix}:{name}"))?;
+                if let Some(cx) = &cx {
+                    // Only write the ns as default if not force prefix
+                    if !force_prefix {
+                        self.output
+                            .write_fmt(format_args!(" xmlns=\"{}\"", cx.default_ns))?;
+                    }
+                }
+                Some(*prefix)
+            }
+            // No prefix case
+            (true, None, _) => {
                 self.output.write_fmt(format_args!("<{name}"))?;
                 None
             }
-            (false, Some(prefix)) => {
-                self.output.write_fmt(format_args!("<{prefix}:{name}"))?;
+            // If ns == default ns and force-prefix is false, we ignore prefix
+            (true, Some(_), false) => {
+                self.output.write_fmt(format_args!("<{name}"))?;
+                // Still requalify the ns here because its not the previous default_ns
                 if let Some(cx) = &cx {
                     self.output
                         .write_fmt(format_args!(" xmlns=\"{}\"", cx.default_ns))?;
                 }
+                None
+            }
+            // Force prefix always - when forcing prefix we dont requalify the namespace
+            (true, Some(prefix), true) => {
+                self.output.write_fmt(format_args!("<{prefix}:{name}"))?;
                 Some(*prefix)
             }
             _ => {
@@ -241,11 +263,14 @@ pub struct Element<'a, const N: usize> {
 
 /// Namespace context for serialization
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct Context<const N: usize> {
     /// The default namespace URI
     pub default_ns: &'static str,
     /// Array of namespace prefix mappings
     pub prefixes: [Prefix; N],
+    /// Force prefix to be included always
+    pub force_prefix: bool,
 }
 
 impl<const N: usize> Default for Context<N> {
@@ -253,6 +278,7 @@ impl<const N: usize> Default for Context<N> {
         Self {
             default_ns: Default::default(),
             prefixes: [Prefix { prefix: "", ns: "" }; N],
+            force_prefix: false,
         }
     }
 }

--- a/instant-xml/tests/force-prefix.rs
+++ b/instant-xml/tests/force-prefix.rs
@@ -1,0 +1,119 @@
+use similar_asserts::assert_eq;
+
+use instant_xml::{from_str, to_string, FromXml, ToXml};
+
+#[derive(Debug, PartialEq, Eq, ToXml, FromXml)]
+#[xml(ns(CORE, NE = NESTED), rename = "top")]
+struct TopLevel {
+    #[xml(attribute)]
+    attr: u32,
+    nested: NestedLevel1ForcePrefix,
+}
+
+#[derive(Debug, PartialEq, Eq, ToXml, FromXml)]
+#[xml(ns(NESTED), rename = "nestedLevel1", force_prefix)]
+struct NestedLevel1ForcePrefix {
+    #[xml(attribute)]
+    attr: u32,
+
+    nested_collection_1: Vec<NestedLevel2ForcePrefix>,
+
+    nested_collection_2: Vec<NestedLevel2NotForcedPrefix>,
+}
+
+#[derive(Debug, PartialEq, Eq, ToXml, FromXml)]
+#[xml(ns(NESTED), rename = "nestedLevel2ForcePrefix", force_prefix)]
+struct NestedLevel2ForcePrefix {
+    #[xml(attribute)]
+    attr: u32,
+}
+
+#[derive(Debug, PartialEq, Eq, ToXml, FromXml)]
+#[xml(ns(NESTED), rename = "nestedLevel2NotForcePrefix")]
+struct NestedLevel2NotForcedPrefix {
+    #[xml(attribute)]
+    attr: u32,
+    nested: NestedLevel3NotForcedPrefix,
+}
+
+#[derive(Debug, PartialEq, Eq, ToXml, FromXml)]
+#[xml(ns(NESTED), rename = "nestedLevel3ForcePrefix", force_prefix)]
+struct NestedLevel3NotForcedPrefix {
+    #[xml(attribute)]
+    attr: u32,
+}
+
+const CORE: &str = "CORE";
+const NESTED: &str = "NESTED";
+
+#[test]
+fn test_toxml_core() {
+    let core = TopLevel {
+        attr: 0,
+        nested: NestedLevel1ForcePrefix {
+            attr: 1,
+            nested_collection_1: vec![
+                NestedLevel2ForcePrefix { attr: 2 },
+                NestedLevel2ForcePrefix { attr: 3 },
+            ],
+            nested_collection_2: vec![NestedLevel2NotForcedPrefix {
+                attr: 4,
+                nested: NestedLevel3NotForcedPrefix { attr: 5 },
+            }],
+        },
+    };
+
+    let core_string = to_string(&core).unwrap();
+
+    let xml_string = r##"<top xmlns="CORE" xmlns:NE="NESTED" attr="0"><NE:nestedLevel1 attr="1"><NE:nestedLevel2ForcePrefix attr="2" /><NE:nestedLevel2ForcePrefix attr="3" /><nestedLevel2NotForcePrefix xmlns="NESTED" attr="4"><NE:nestedLevel3ForcePrefix attr="5" /></nestedLevel2NotForcePrefix></NE:nestedLevel1></top>"##;
+
+    assert_eq!(xml_string, core_string);
+}
+
+#[test]
+fn test_fromxml_with_parent_ns_only() {
+    let core = TopLevel {
+        attr: 0,
+        nested: NestedLevel1ForcePrefix {
+            attr: 1,
+            nested_collection_1: vec![
+                NestedLevel2ForcePrefix { attr: 2 },
+                NestedLevel2ForcePrefix { attr: 3 },
+            ],
+            nested_collection_2: vec![NestedLevel2NotForcedPrefix {
+                attr: 4,
+                nested: NestedLevel3NotForcedPrefix { attr: 5 },
+            }],
+        },
+    };
+
+    let xml_string = r##"<top xmlns="CORE" xmlns:NE="NESTED" attr="0"><NE:nestedLevel1 attr="1"><NE:nestedLevel2ForcePrefix attr="2" /><NE:nestedLevel2ForcePrefix attr="3" /><NE:nestedLevel2NotForcePrefix attr="4"><NE:nestedLevel3ForcePrefix attr="5" /></NE:nestedLevel2NotForcePrefix></NE:nestedLevel1></top>"##;
+
+    let core_from_xml = from_str::<TopLevel>(xml_string).unwrap();
+
+    assert_eq!(core_from_xml, core);
+}
+
+#[test]
+fn test_fromxml_with_mixed_ns_handling() {
+    let core = TopLevel {
+        attr: 0,
+        nested: NestedLevel1ForcePrefix {
+            attr: 1,
+            nested_collection_1: vec![
+                NestedLevel2ForcePrefix { attr: 2 },
+                NestedLevel2ForcePrefix { attr: 3 },
+            ],
+            nested_collection_2: vec![NestedLevel2NotForcedPrefix {
+                attr: 4,
+                nested: NestedLevel3NotForcedPrefix { attr: 5 },
+            }],
+        },
+    };
+
+    let xml_string = r##"<top xmlns="CORE" xmlns:NE="NESTED" attr="0"><NE:nestedLevel1 attr="1"><NE:nestedLevel2ForcePrefix attr="2" /><NE:nestedLevel2ForcePrefix attr="3" /><nestedLevel2NotForcePrefix xmlns="NESTED" attr="4"><NE:nestedLevel3ForcePrefix attr="5" /></nestedLevel2NotForcePrefix></NE:nestedLevel1></top>"##;
+
+    let core_from_xml = from_str::<TopLevel>(xml_string).unwrap();
+
+    assert_eq!(core_from_xml, core);
+}


### PR DESCRIPTION
- Added a new attribute for structs called force_prefix 
- Specifying force_prefix will force the current item to always force to define the local name with prefix and not requalify its default namespace in the start element
- Skipping the new attribute preserves the current default behavior (all new namespaces in the subtree are requalified as the default namespace on the first element in the hierarchy of the tree)
- Adding the attribute on enums, fields or inline structs, will be a compile error. 