### PR TITLE
Add lookup utility to the Deserializer context

### DIFF
--- a/instant-xml/src/de.rs
+++ b/instant-xml/src/de.rs
@@ -95,6 +95,10 @@ impl<'cx, 'xml> Deserializer<'cx, 'xml> {
         }
     }
 
+    pub fn namespace(&self, prefix: &str) -> Option<&'xml str> {
+        self.context.lookup(prefix)
+    }
+
     /// Get the identifier of an element (name and namespace)
     #[inline]
     pub fn element_id(&self, element: &Element<'xml>) -> Result<Id<'xml>, Error> {


### PR DESCRIPTION
Sorry, I only got time yesterday to merge the changes into my library and I see you are already working on some fixes that were not properly considered before. 

If there is anything else I can help with please let me know. 

In the meantime, for my use case it would be very useful to have the possibility of querying all the namespace and namespace prefixes found in a manual FromXml implementation. 

The motivation for this is because in the 3MF spec, they have an additional attribute to be used by the readers and writers to specify the required extensions to parse the file, and by having this lookup available on the Deserializer I can create more concrete types from it. 

```rust
impl<'xml> FromXml<'xml> for ThreemfNamespaceCollection {
    fn matches(id: instant_xml::Id<'_>, field: Option<instant_xml::Id<'_>>) -> bool {
        match field {
            Some(field) => id == field,
            None => false,
        }
    }

    fn deserialize<'cx>(
        into: &mut Self::Accumulator,
        _field: &'static str,
        deserializer: &mut instant_xml::Deserializer<'cx, 'xml>,
    ) -> Result<(), instant_xml::Error> {
        if let Some(value) = deserializer.take_str()? {
            let mut ns_collection = vec![];
            for prefix in value.split_whitespace() {
                if let Some(uri) = deserializer.lookup_ns(prefix)
                    && let Some(ns) = ThreemfNamespace::try_from_uri(uri, Some(prefix))
                {
                    ns_collection.push(ns);
                }
            }
            *into = Self(ns_collection);
        } else {
            *into = Self(vec![]);
        }

        Ok(())
    }

    type Accumulator = Self;

    const KIND: instant_xml::Kind = instant_xml::Kind::Scalar;
}

#[cfg(feature = "memory-optimized-read")]
impl instant_xml::Accumulate<ThreemfNamespaceCollection> for ThreemfNamespaceCollection {
    fn try_done(self, _: &'static str) -> Result<ThreemfNamespaceCollection, instant_xml::Error> {
        Ok(self)
    }
}
```