### PR TITLE
Potential reduction in unnessary allocation

### DIFF
--- a/instant-xml/src/de.rs
+++ b/instant-xml/src/de.rs
@@ -399,6 +399,10 @@ pub fn borrow_cow_slice_u8<'xml>(
 }
 
 fn decode(input: &str) -> Result<Cow<'_, str>, Error> {
+    if !input.as_bytes().contains(&b'&') {
+        return Ok(Cow::Borrowed(input));
+    }
+
     let mut result = String::with_capacity(input.len());
     let (mut state, mut last_end) = (DecodeState::Normal, 0);
     for (i, &b) in input.as_bytes().iter().enumerate() {


### PR DESCRIPTION
I was investigating further performance improvement in my library when I noticed that there were a pretty significant range of heap allocation and deallocation happening in the Context::next function. 

### Overall view of my single from_str call
<img width="2090" height="631" alt="image" src="https://github.com/user-attachments/assets/e31baf1a-67dd-48df-a00d-770b1e8f6801" />

### Zoomed in view of a single leading region with total execution %:
<img width="1405" height="792" alt="image" src="https://github.com/user-attachments/assets/99022fb2-b844-4c5a-8bec-e171c352eaa6" />

In my specific workload this allocation and deallocation made up consistenly 15-20% of the execution time. 

I am not an expert at XML decode, however, If we could just avoid the default String allocation on the case that the value does not contain any decode-able bytes, it seems it can already significantly improve speed in some workloads. 

### Process after adding an early return in `fn decode`

<img width="2205" height="515" alt="image" src="https://github.com/user-attachments/assets/c5d5e84e-3e17-435d-8502-0fc18f6a8b0d" />

I have a consistent 15-18% improvement in speed across my benchmark suite from small(2KB) XML up to a large(600MB) XML deserialization. 

If this is not the best way to skip this allocation, feel free to provide guidance if there are alternatives I could try. 