### PR TITLE
Bump instant-xml version to 0.7.5

### DIFF
--- a/instant-xml/Cargo.toml
+++ b/instant-xml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instant-xml"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 rust-version = "1.71"
 workspace = ".."


### PR DESCRIPTION
Bumped the version of instant-xml for the fix, missed it in previous PR. 